### PR TITLE
Fix intermittend failed update

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ app.get('/', (request, response) => {
 
 app.get('/readinessProbe', (request, response) => {
   response.sendStatus(200);
-})
+});
 
 app.post('/api/post/parsexml', (request, response) => {
   // Check for missing body and platform
@@ -55,17 +55,13 @@ app.post('/api/post/parsexml', (request, response) => {
     response.send("No fails or errors found").status(200);
     return;
   }
-  
+
   const parsedFilteredFailedTests = parserUtils.parseBodyXml(request.body, platform);
   console.log("found fails:", parsedFilteredFailedTests.length);
 
-  databaseAccessLayer.saveToDatabase(platform, parsedFilteredFailedTests, (res, err) => {
-    if(err) {
-      response.send(res).status(400);
-    } else {
-      response.sendStatus(200);
-    }
+  databaseAccessLayer.saveToDatabase(platform, parsedFilteredFailedTests).then(() => {
+    response.sendStatus(200);
   });
-})
+});
 
 app.listen(3000);

--- a/index.js
+++ b/index.js
@@ -59,9 +59,13 @@ app.post('/api/post/parsexml', (request, response) => {
   const parsedFilteredFailedTests = parserUtils.parseBodyXml(request.body, platform);
   console.log("found fails:", parsedFilteredFailedTests.length);
 
-  databaseAccessLayer.saveToDatabase(platform, parsedFilteredFailedTests).then(() => {
-    response.sendStatus(200);
-  });
+  databaseAccessLayer.saveToDatabase(platform, parsedFilteredFailedTests)
+    .then(() => {
+      response.sendStatus(200);
+    })
+    .catch((err) => {
+      response.send("Error:" + err).status(500);
+    });
 });
 
 app.listen(3000);

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -26,7 +26,7 @@ async function saveToDatabase(platform, parsedFails) {
 }
 
 async function findAndUpdateFailInDb(failElem) {
-  await collection.findOneAndUpdate({
+  const response = await collection.updateOne({
     classname         : failElem.classname,
     testname          : failElem.testname,
   },{
@@ -37,6 +37,7 @@ async function findAndUpdateFailInDb(failElem) {
     console.log("Could update a fail:)");
     console.log(err);
   });
+  console.log(response.result);
 }
 
 async function getFails() {

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -39,7 +39,8 @@ async function findAndUpdateFailInDb(failElem) {
         'fail.numOfFails': 1
       }
     }, {
-      upsert: true
+      upsert: true,
+      unique: true
     });
   } catch (e) {
     console.error('Failing to write to a DB');

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -22,8 +22,8 @@ async function saveToDatabase(platform, parsedFails) {
     collection = dbo.collection(platform);
     collection.createIndex({classname:1, testname:1}, {unique: true})
     for (const failElem of parsedFails) {
-      await collection.insert(failElem).catch(async (err) => {
-        await findAndUpdateFailInDb(failElem);
+      await collection.insertOne(failElem).catch((err) => {
+        findAndUpdateFailInDb(failElem);
       })
     }
     db.close();
@@ -31,20 +31,19 @@ async function saveToDatabase(platform, parsedFails) {
 }
 
 async function findAndUpdateFailInDb(failElem) {
-  try {
-    await collection.findOneAndUpdate({
-      classname         : failElem.classname,
-      testname          : failElem.testname,
-      'fail.failMsg'    : failElem.fail.failMsg,
-      'fail.stackTrace' : failElem.fail.stackTrace
-    }, {
-      $inc: {
-        'fail.numOfFails': 1
-      }
-    });
-  } catch (e) {
-    console.error("Failed to insert and update");
-  }
+  await collection.findOneAndUpdate({
+    classname         : failElem.classname,
+    testname          : failElem.testname,
+    'fail.failMsg'    : failElem.fail.failMsg,
+    'fail.stackTrace' : failElem.fail.stackTrace
+  },{
+    $inc: {
+      'fail.numOfFails': 1
+    }
+  }).catch((err) => {
+    console.log("Could update a fail:)");
+    console.log(err);
+  });
 }
 
 async function getFails() {

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -11,27 +11,25 @@ const url = `mongodb://${_const.DB_USERNAME}:${_const.DB_PASSWORD}@${_const.DB_U
 
 var collection = null;
 
-function saveToDatabase(platform, parsedFails, callback) {
+async function saveToDatabase(platform, parsedFails) {
   MongoClient.connect(url, { useNewUrlParser: true }, async function(err, db) {
     if (err) {
-      console.error(err)
-      callback(err, true)
-      return;
+      console.error(err);
+      throw err;
     };
     console.log("Connected to DB");
     const dbo = db.db(_const.DB_NAME);
     collection = dbo.collection(platform);
     for (const failElem of parsedFails) {
-      findAndUpdateFailInDb(failElem);
+      await findAndUpdateFailInDb(failElem);
     }
     db.close();
-    callback("OK", false);
   });
 }
 
 async function findAndUpdateFailInDb(failElem) {
   try {
-    await collection.updateOne({ 
+    await collection.updateOne({
       classname         : failElem.classname,
       testname          : failElem.testname,
       'fail.failMsg'    : failElem.fail.failMsg,

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -22,20 +22,15 @@ async function saveToDatabase(platform, parsedFails) {
     collection = dbo.collection(platform);
     collection.createIndex({classname:1, testname:1}, {unique: true})
     for (const failElem of parsedFails) {
-      await findAndUpdateFailInDb(failElem, (element, e) => {
-        // As per https://docs.mongodb.com/manual/reference/method/db.collection.findAndModify/#upsert-and-unique-index,
-        // if we fail the first upsert, we should try again, in which case the upsert should continue
-        findAndUpdateFailInDb(element, (element, e) => {
-          console.error('Failed to write again', e);
-          throw e;
-        });
-      });
+      await collection.insert(failElem).catch(async (err) => {
+        await findAndUpdateFailInDb(failElem);
+      })
     }
     db.close();
   });
 }
 
-async function findAndUpdateFailInDb(failElem, callback) {
+async function findAndUpdateFailInDb(failElem) {
   try {
     await collection.findOneAndUpdate({
       classname         : failElem.classname,
@@ -46,12 +41,9 @@ async function findAndUpdateFailInDb(failElem, callback) {
       $inc: {
         'fail.numOfFails': 1
       }
-    }, {
-      upsert: true
     });
   } catch (e) {
-    console.error("Failed to upsert; Trying again");
-    callback(failElem, e);
+    console.error("Failed to insert and update");
   }
 }
 

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -20,21 +20,24 @@ async function saveToDatabase(platform, parsedFails) {
     console.log("Connected to DB");
     const dbo = db.db(_const.DB_NAME);
     collection = dbo.collection(platform);
-    try {
-      collection.createIndex({classname:1, testname:1}, {unique: true})
-    } catch (e) {
-      //
-    }
+    collection.createIndex({classname:1, testname:1}, {unique: true})
     for (const failElem of parsedFails) {
-      await findAndUpdateFailInDb(failElem);
+      await findAndUpdateFailInDb(failElem, (element, e) => {
+        // As per https://docs.mongodb.com/manual/reference/method/db.collection.findAndModify/#upsert-and-unique-index,
+        // if we fail the first upsert, we should try again, in which case the upsert should continue
+        findAndUpdateFailInDb(element, (element, e) => {
+          console.error('Failed to write again', e);
+          throw e;
+        });
+      });
     }
     db.close();
   });
 }
 
-async function findAndUpdateFailInDb(failElem) {
+async function findAndUpdateFailInDb(failElem, callback) {
   try {
-    await collection.updateOne({
+    await collection.findOneAndUpdate({
       classname         : failElem.classname,
       testname          : failElem.testname,
       'fail.failMsg'    : failElem.fail.failMsg,
@@ -44,13 +47,11 @@ async function findAndUpdateFailInDb(failElem) {
         'fail.numOfFails': 1
       }
     }, {
-      upsert: true,
-      unique: true
+      upsert: true
     });
   } catch (e) {
-    console.error('Failing to write to a DB');
-    console.error(e);
-    throw e;
+    console.error("Failed to upsert; Trying again");
+    callback(failElem, e);
   }
 }
 

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -12,30 +12,23 @@ const url = `mongodb://${_const.DB_USERNAME}:${_const.DB_PASSWORD}@${_const.DB_U
 var collection = null;
 
 async function saveToDatabase(platform, parsedFails) {
-  MongoClient.connect(url, { useNewUrlParser: true }, async function(err, db) {
-    if (err) {
-      console.error(err);
-      throw err;
-    };
-    console.log("Connected to DB");
-    const dbo = db.db(_const.DB_NAME);
-    collection = dbo.collection(platform);
-    collection.createIndex({classname:1, testname:1}, {unique: true})
-    for (const failElem of parsedFails) {
-      await collection.insertOne(failElem).catch((err) => {
-        findAndUpdateFailInDb(failElem);
-      })
-    }
-    db.close();
-  });
+  const db = await MongoClient.connect(url, { useNewUrlParser: true });
+  console.log("Connected to DB");
+  const dbo = db.db(_const.DB_NAME);
+  collection = dbo.collection(platform);
+  collection.createIndex({classname:1, testname:1}, {unique: true})
+  for (const failElem of parsedFails) {
+    await collection.insertOne(failElem).catch(async (err) => {
+      await findAndUpdateFailInDb(failElem);
+    })
+  }
+  db.close();
 }
 
 async function findAndUpdateFailInDb(failElem) {
   await collection.findOneAndUpdate({
     classname         : failElem.classname,
     testname          : failElem.testname,
-    'fail.failMsg'    : failElem.fail.failMsg,
-    'fail.stackTrace' : failElem.fail.stackTrace
   },{
     $inc: {
       'fail.numOfFails': 1

--- a/lib/failsDAL.js
+++ b/lib/failsDAL.js
@@ -20,6 +20,11 @@ async function saveToDatabase(platform, parsedFails) {
     console.log("Connected to DB");
     const dbo = db.db(_const.DB_NAME);
     collection = dbo.collection(platform);
+    try {
+      collection.createIndex({classname:1, testname:1}, {unique: true})
+    } catch (e) {
+      //
+    }
     for (const failElem of parsedFails) {
       await findAndUpdateFailInDb(failElem);
     }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-scss": "node-sass --include-path scss scss/main.scss public/css/main.css",
     "watch-scss": "nodemon -e scss -x \"npm run build-scss\"",
     "watch-js": "nodemon index.js",
-    "start" : "npm run build-scss && npm run watch-js"
+    "start" : "npm run watch-js"
   },
   "keywords": [
     "noe"


### PR DESCRIPTION
In MongoDB, `upsert` is not an atomic operation in MongDB. As a consequence, at times, we did not update the DB properly. This PR:

- Fixes creation of multiple objects in DB (we want them to be unique)
- Fixes intermittent update fail in concurrent environment (5+ requests around the same time)
- Fixes some style errors
- Provides better logging