### PR TITLE
Build css on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build-scss": "node-sass --include-path scss scss/main.scss public/css/main.css",
     "watch-scss": "nodemon -e scss -x \"npm run build-scss\"",
     "watch-js": "nodemon index.js",
-    "start": "npm run watch-js"
+    "start": "npm run build-scss && npm run watch-js"
   },
   "keywords": [
     "noe"
@@ -21,10 +21,10 @@
     "express-xml-bodyparser": "^0.3.0",
     "mongodb": "^3.1.8",
     "patternfly": "^3.55.0",
+    "node-sass": "^4.9.4",
     "serve-favicon": "^2.5.0"
   },
   "devDependencies": {
-    "node-sass": "^4.9.4",
     "nodemon": "^1.18.4"
   }
 }


### PR DESCRIPTION
This PR resolves issue #4 . It has been tested on OCP and works as expected; scss is built into css upon deployment.